### PR TITLE
Upgrade kaomoji-slack to use Slack Auth v2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 jlmart88
+Copyright (c) 2021 jlmart88
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # kaomoji-slack
+
 A Slack app for kaomoji
 
 # Setup
@@ -6,8 +7,16 @@ A Slack app for kaomoji
 ## Local Development
 
 1. `npm i`
-1. Create and fill out `env_files/compose.env`
-1. `docker-compose start`
+1. Create and fill out `env_files/compose.env` using the credentials from **App Settings** > **Basic Information**
+1. `docker-compose up`
 1. In a separate tab, `ngrok http 3000`
 1. Copy the domain given by `ngrok` into the Slack Development App, into the
-**Interactive Components**, **Slash Commands**, and **OAuth & Permissions** sections.
+   **Interactivity & Shortcuts**, **Slash Commands**, and **OAuth & Permissions** sections.
+1. Changes will be applied from tear down + restarting docker.
+1. Teardown: `docker-compose down`
+
+Accessing the database:
+
+1. Get the ID of the service running MongoDB by running `docker-compose ps -q`
+1. Run `docker exec -it <service-id> /bin/sh`
+1. In the docker shell run `mongo <MONGODB_URI>` using the URI from the .env file.

--- a/public/faq.html
+++ b/public/faq.html
@@ -121,7 +121,7 @@
         <div class="ui container">
             <div class="ui stackable inverted divided equal height grid">
                 <div class="center aligned centered column">
-                    Copyright © 2017 Justin Martinez | <a href="/privacy">Privacy Policy</a>
+                    Copyright © 2021 Justin Martinez | <a href="/privacy">Privacy Policy</a>
                 </div>
             </div>
         </div>

--- a/public/home.html
+++ b/public/home.html
@@ -113,7 +113,7 @@
         <div class="ui container">
             <div class="ui stackable inverted divided equal height grid">
                 <div class="center aligned centered column">
-                    Copyright © 2017 Justin Martinez | <a href="/privacy">Privacy Policy</a>
+                    Copyright © 2021 Justin Martinez | <a href="/privacy">Privacy Policy</a>
                 </div>
             </div>
         </div>

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -67,7 +67,7 @@
         <div class="ui container">
             <div class="ui stackable inverted divided equal height grid">
                 <div class="center aligned centered column">
-                    Copyright © 2017 Justin Martinez | <a href="/privacy">Privacy Policy</a>
+                    Copyright © 2021 Justin Martinez | <a href="/privacy">Privacy Policy</a>
                 </div>
             </div>
         </div>

--- a/public/success.html
+++ b/public/success.html
@@ -47,7 +47,7 @@
         <div class="ui container">
             <div class="ui stackable inverted divided equal height grid">
                 <div class="center aligned centered column">
-                    Copyright © 2017 Justin Martinez | <a href="/privacy">Privacy Policy</a>
+                    Copyright © 2021 Justin Martinez | <a href="/privacy">Privacy Policy</a>
                 </div>
             </div>
         </div>

--- a/routes/oauth.ts
+++ b/routes/oauth.ts
@@ -13,9 +13,9 @@ router.get('/', (req, res) => {
   } else {
     // If it's there...
 
-    // We'll do a GET call to Slack's `oauth.access` endpoint, passing our app's client ID, client secret, and the code we just got as query parameters.
+    // We'll do a GET call to Slack's `oauth.v2.access` endpoint, passing our app's client ID, client secret, and the code we just got as query parameters.
     request({
-      url: 'https://slack.com/api/oauth.access', //URL to hit
+      url: 'https://slack.com/api/oauth.v2.access', //URL to hit
       qs: {
         code: req.query.code,
         client_id: config.SLACK_CLIENT_ID,
@@ -52,7 +52,7 @@ router.get('/', (req, res) => {
 });
 
 router.get('/signin', (req, res) => {
-  res.redirect('https://slack.com/oauth/authorize?scope=commands+chat:write:user&client_id=' + config.SLACK_CLIENT_ID);
+  res.redirect(`https://slack.com/oauth/v2/authorize?client_id=${config.SLACK_CLIENT_ID}&scope=chat:write,chat:write.public,commands`);
 });
 
 export default router;


### PR DESCRIPTION
## Overview
Follows [these instructions](https://api.slack.com/authentication/migration?utm_medium=referral&utm_source=email&utm_campaign=fy21-granular-permissions) for upgrading from bot tokens to granular bot tokens.

Also updated the README and bumped up the copyright years.

## Testing
Tested manually that

- User may authenticate to add kaomoji-slack to Slack
- User's data is saved correctly in the database
- User may use Kaomoji app in Slack once authenticated